### PR TITLE
broken labels that begin with a slash

### DIFF
--- a/src/phpDocumentor/GraphViz/Attribute.php
+++ b/src/phpDocumentor/GraphViz/Attribute.php
@@ -99,7 +99,7 @@ class Attribute
         }
 
         $value = $this->getValue();
-        if (!$this->isValueInHtml() && !$this->isValueContainingSpecials()) {
+        if (!$this->isValueInHtml() || $this->isValueContainingSpecials()) {
             $value = '"' . addslashes($value) . '"';
         }
         return $key . '=' . $value;


### PR DESCRIPTION
when there is a special char in we still need to call addslashes for the value and also need to quote the value else the output is still broken and can't be read be dot (tested with 2.34 and 2.36)
