### PR TITLE
Encode specials correctly.

### DIFF
--- a/src/phpDocumentor/GraphViz/Attribute.php
+++ b/src/phpDocumentor/GraphViz/Attribute.php
@@ -132,12 +132,12 @@ class Attribute
     /**
      * Encode special characters so the escape sequences aren't removed
      *
+     * @see http://www.graphviz.org/doc/info/attrs.html#k:escString
      * @return string
      */
     protected function encodeSpecials()
     {
         $value = $this->getValue();
-        $validEscapes = 'NGEGTHLnlr';
         $regex = '(\'|"|\\x00|\\\\(?![\\\\NGETHLnlr]))';
         return preg_replace($regex, '\\\\$0', $value);
     }

--- a/src/phpDocumentor/GraphViz/Attribute.php
+++ b/src/phpDocumentor/GraphViz/Attribute.php
@@ -99,7 +99,9 @@ class Attribute
         }
 
         $value = $this->getValue();
-        if (!$this->isValueInHtml() || $this->isValueContainingSpecials()) {
+        if ($this->isValueContainingSpecials()) {
+            $value = '"' . $this->encodeSpecials() . '"';
+        } elseif (!$this->isValueInHtml()) {
             $value = '"' . addslashes($value) . '"';
         }
         return $key . '=' . $value;
@@ -125,5 +127,18 @@ class Attribute
     public function isValueContainingSpecials()
     {
         return strstr($this->getValue(), "\\") !== false;
+    }
+
+    /**
+     * Encode special characters so the escape sequences aren't removed
+     *
+     * @return string
+     */
+    protected function encodeSpecials()
+    {
+        $value = $this->getValue();
+        $validEscapes = 'NGEGTHLnlr';
+        $regex = '(\'|"|\\x00|\\\\(?![\\\\NGETHLnlr]))';
+        return preg_replace($regex, '\\\\$0', $value);
     }
 }

--- a/tests/phpDocumentor/GraphViz/Test/AttributeTest.php
+++ b/tests/phpDocumentor/GraphViz/Test/AttributeTest.php
@@ -159,6 +159,35 @@ class AttributeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests whether the toString provides a valid GraphViz attribute string.
+     *
+     * @covers \phpDocumentor\GraphViz\Attribute::__toString
+     * @covers \phpDocumentor\GraphViz\Attribute::encodeSpecials
+     *
+     * @return void
+     */
+    public function testToStringWithSpecials()
+    {
+        $this->fixture = new Attribute('a', 'b');
+
+        $this->fixture->setValue('a\la');
+        $this->assertSame(
+            'a="a\la"', (string)$this->fixture,
+            'Specials should not be escaped'
+        );
+        $this->fixture->setValue('a\l"a');
+        $this->assertSame(
+            'a="a\l\"a"', (string)$this->fixture,
+            'Specials should not be escaped, but quotes should'
+        );
+        $this->fixture->setValue('a\\\\l"a');
+        $this->assertSame(
+            'a="a\\\\l\"a"', (string)$this->fixture,
+            'Double backslashes should stay the same'
+        );
+    }
+
+    /**
      * Tests whether the isValueContainingSpecials function
      *
      * @covers \phpDocumentor\GraphViz\Attribute::isValueContainingSpecials
@@ -173,4 +202,6 @@ class AttributeTest extends \PHPUnit_Framework_TestCase
         $this->fixture->setValue('+ ship(): boolean');
         $this->assertFalse($this->fixture->isValueContainingSpecials());
     }
+
+    
 }


### PR DESCRIPTION
Currently, all special escape sequences are double-escaped, converting \l into \\\\l. This means that you cannot use an escape sequence in any of the attributes.

This patch encodes the value while leaving escape sequences in play. It uses the valid escape sequences listed http://www.graphviz.org/doc/info/attrs.html#k:escString: